### PR TITLE
Переформатировал сообщение о ближайшем медике.

### DIFF
--- a/co40_Invade_Annex_2_77.Altis/scripts/=BTC=_revive/=BTC=_functions.sqf
+++ b/co40_Invade_Annex_2_77.Altis/scripts/=BTC=_revive/=BTC=_functions.sqf
@@ -619,7 +619,7 @@ BTC_check_healer =
 			{
 				if (_x distance _pos < _dist) then {_healer = _x;_dist = _x distance _pos;};
 			} foreach _healers;
-			if !(isNull _healer) then {_msg = format ["Медик %1 находится на расстоянии %2м.", name _healer,round(_healer distance _pos)];};
+			if !(isNull _healer) then {_msg = format ["Наш медик (%1) находится на расстоянии %2м.", name _healer,round(_healer distance _pos)];};
 		};
 	};
 	_msg


### PR DESCRIPTION
Думаю так еще лучше, в контексте с противоположным - "Поблизости нет наших медиков!" Ключевое слово «наш», а то на поле боя и вражеские медики есть, но хрен кто из такистанцев про клятву Гиппократа знает.
